### PR TITLE
Add User-Agent to _commonHeaders

### DIFF
--- a/src/main/java/io/split/fastly/client/FastlyApiClient.java
+++ b/src/main/java/io/split/fastly/client/FastlyApiClient.java
@@ -40,7 +40,7 @@ public class FastlyApiClient {
 
     public FastlyApiClient(final String apiKey, final String serviceId, AsyncHttpClientConfig config) {
 
-        _commonHeaders = ImmutableMap.of("Fastly-Key", apiKey, "Accept", "application/json");
+        _commonHeaders = ImmutableMap.of("Fastly-Key", apiKey, "Accept", "application/json", "User-Agent", "fastly-api-java");
         _config = config;
         _apiKey = apiKey;
         _serviceId = serviceId;


### PR DESCRIPTION
Ideally, we’d also want to append the version number of this java library to the value of this header ("fastly-api-java-v[VERSION]"), but I couldn’t find the version of this library. Any ideas there? 

And full disclosure: I'm not great at Java! Be gentle 😄 
