### PR TITLE
Add support to purge multiple surrogate keys

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,7 @@ Changelog
 
 1.2
  Include softPurgeKeys to allow batch call to purge by multiple surrogate keys.
+ Add precondition check to validate we can only pass up to 256 keys.
 
 1.1
  Include client version on each request. Example: `"User-Agent" -> "fastly-api-java-v1.1"`

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,11 @@
+Changelog
+---------
+
+1.2
+ Include softPurgeKeys to allow batch call to purge by multiple surrogate keys.
+
+1.1
+ Include client version on each request. Example: `"User-Agent" -> "fastly-api-java-v1.1"`
+
+1.0
+ initial version

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Java API Wrapper for Fastly (https://docs.fastly.com/api)
     .....
 ```
 
+# Build
+
+```export GPG_TTY=$(tty) && mvn clean install```
+
 # Run tests
 
 Create a file under src/test/resources called: keys.properties containing:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.split</groupId>
   <artifactId>fastly-api-java</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.2</version>
   <packaging>jar</packaging>
 
   <name>fastly-api-java</name>
@@ -78,6 +78,9 @@
             <goals>
               <goal>jar</goal>
             </goals>
+            <configuration>
+              <source>1.8</source>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -85,7 +88,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -134,6 +137,7 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/src/main/java/io/split/fastly/client/FastlyApiClient.java
+++ b/src/main/java/io/split/fastly/client/FastlyApiClient.java
@@ -123,7 +123,9 @@ public class FastlyApiClient {
     }
 
     public Future<Response> softPurgeKeys(List<String> keys) {
-        Preconditions.checkArgument(keys != null && keys.size() <= 256, "Fastly batches can only receive up to 256 keys");
+        Preconditions.checkNotNull(keys, "keys cannot be null!");
+        Preconditions.checkArgument(keys.size() <= 256, "Fastly can't purge batches of more than 256 keys");
+
         String apiUrl = String.format("%s/service/%s/purge", FASTLY_URL, _serviceId);
         return _asyncHttpExecutor.execute(
                 apiUrl,

--- a/src/main/java/io/split/fastly/client/FastlyApiClient.java
+++ b/src/main/java/io/split/fastly/client/FastlyApiClient.java
@@ -1,5 +1,6 @@
 package io.split.fastly.client;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.AsyncHttpClientConfig;
@@ -32,6 +33,7 @@ public class FastlyApiClient {
     private final AsyncHttpExecutor _asyncHttpExecutor;
     private final String _serviceId;
     private final String _apiKey;
+    private final Joiner SURROGATE_KEY_JOINER = Joiner.on(" ");
 
 
     public FastlyApiClient(final String apiKey, final String serviceId) {
@@ -105,6 +107,18 @@ public class FastlyApiClient {
 
     public Future<Response> softPurgeKey(String key, Map<String, String> extraHeaders) {
         return purgeKey(key, buildHeaderForSoftPurge(extraHeaders));
+    }
+
+    public Future<Response> softPurgeKeys(List<String> keys) {
+        String apiUrl = String.format("%s/service/%s/purge", FASTLY_URL, _serviceId);
+        return _asyncHttpExecutor.execute(
+                apiUrl,
+                POST,
+                ImmutableMap.<String, String> builder()
+                        .put("Fastly-Key", _apiKey)
+                        .put("Surrogate-Key", SURROGATE_KEY_JOINER.join(keys))
+                        .build(),
+                Collections.EMPTY_MAP);
     }
 
     public Future<Response> softPurgeKey(String key) {

--- a/src/main/java/io/split/fastly/client/FastlyApiClient.java
+++ b/src/main/java/io/split/fastly/client/FastlyApiClient.java
@@ -1,6 +1,7 @@
 package io.split.fastly.client;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.ning.http.client.AsyncHttpClient;
 import com.ning.http.client.AsyncHttpClientConfig;
@@ -122,6 +123,7 @@ public class FastlyApiClient {
     }
 
     public Future<Response> softPurgeKeys(List<String> keys) {
+        Preconditions.checkArgument(keys != null && keys.size() <= 256, "Fastly batches can only receive up to 256 keys");
         String apiUrl = String.format("%s/service/%s/purge", FASTLY_URL, _serviceId);
         return _asyncHttpExecutor.execute(
                 apiUrl,

--- a/src/main/java/io/split/fastly/client/FastlyApiClient.java
+++ b/src/main/java/io/split/fastly/client/FastlyApiClient.java
@@ -57,7 +57,10 @@ public class FastlyApiClient {
         return _asyncHttpExecutor.execute(
                 apiUrl,
                 POST,
-                ImmutableMap.<String, String> builder().putAll(_commonHeaders).put("Content-Type", "application/x-www-form-urlencoded").build(),
+                ImmutableMap.<String, String> builder()
+                        .putAll(_commonHeaders)
+                        .put("Content-Type", "application/x-www-form-urlencoded")
+                        .build(),
                 ImmutableMap.<String, String> builder().put("content", vcl).put("name", name).put("id", id).build());
     }
 
@@ -67,7 +70,10 @@ public class FastlyApiClient {
             return _asyncHttpExecutor.execute(
                     apiUrl,
                     PUT,
-                    ImmutableMap.<String, String> builder().putAll(_commonHeaders).put("Content-Type", "application/x-www-form-urlencoded").build(),
+                    ImmutableMap.<String, String> builder()
+                            .putAll(_commonHeaders)
+                            .put("Content-Type", "application/x-www-form-urlencoded")
+                            .build(),
                     ImmutableMap.<String, String> builder().put("content", e.getValue()).put("name", e.getKey()).build());
 
             }).collect(toList());
@@ -100,7 +106,10 @@ public class FastlyApiClient {
         return _asyncHttpExecutor.execute(
                 apiUrl,
                 POST,
-                ImmutableMap.<String, String> builder().put("Fastly-Key", _apiKey).putAll(extraHeaders).build(),
+                ImmutableMap.<String, String> builder()
+                        .putAll(_commonHeaders)
+                        .putAll(extraHeaders)
+                        .build(),
                 Collections.EMPTY_MAP);
     }
 
@@ -118,7 +127,7 @@ public class FastlyApiClient {
                 apiUrl,
                 POST,
                 ImmutableMap.<String, String> builder()
-                        .put("Fastly-Key", _apiKey)
+                        .putAll(_commonHeaders)
                         .put("Surrogate-Key", SURROGATE_KEY_JOINER.join(keys))
                         .build(),
                 Collections.EMPTY_MAP);

--- a/src/test/java/io/split/FastlyApiClientTest.java
+++ b/src/test/java/io/split/FastlyApiClientTest.java
@@ -47,4 +47,14 @@ public class FastlyApiClientTest extends BaseFastlyTest {
         printResult(res);
     }
 
+    @Test
+    public void testPurgeKey() throws ExecutionException, InterruptedException, IOException {
+        FastlyApiClient client = new FastlyApiClient(_fastly_api_key, _fastly_service_id, null);
+
+        Future<Response> future = client.softPurgeKey("a");
+        Response res = future.get();
+
+        printResult(res);
+    }
+
 }

--- a/src/test/java/io/split/FastlyApiClientTest.java
+++ b/src/test/java/io/split/FastlyApiClientTest.java
@@ -1,8 +1,8 @@
 package io.split;
 
+import com.google.common.collect.Lists;
 import com.ning.http.client.Response;
 import io.split.fastly.client.FastlyApiClient;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -35,6 +35,16 @@ public class FastlyApiClientTest extends BaseFastlyTest {
         System.out.println(res.getStatusCode());
         System.out.println(res.getStatusText());
         System.out.println(res.getResponseBody());
+    }
+
+    @Test
+    public void testPurgeMultipleKeys() throws ExecutionException, InterruptedException, IOException {
+        FastlyApiClient client = new FastlyApiClient(_fastly_api_key, _fastly_service_id, null);
+
+        Future<Response> future = client.softPurgeKeys(Lists.newArrayList("a", "b", "c", "d"));
+        Response res = future.get();
+
+        printResult(res);
     }
 
 }

--- a/src/test/java/io/split/FastlyApiClientTest.java
+++ b/src/test/java/io/split/FastlyApiClientTest.java
@@ -6,8 +6,11 @@ import io.split.fastly.client.FastlyApiClient;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 public class FastlyApiClientTest extends BaseFastlyTest {
 
@@ -42,6 +45,21 @@ public class FastlyApiClientTest extends BaseFastlyTest {
         FastlyApiClient client = new FastlyApiClient(_fastly_api_key, _fastly_service_id, null);
 
         Future<Response> future = client.softPurgeKeys(Lists.newArrayList("a", "b", "c", "d"));
+        Response res = future.get();
+
+        printResult(res);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPurgeMoreThan256Keys() throws ExecutionException, InterruptedException, IOException {
+        List<String> keys = new Random().ints(257,0,10000)
+                .boxed()
+                .map(i -> Integer.toString(i))
+                .collect(Collectors.toList());
+
+        FastlyApiClient client = new FastlyApiClient(_fastly_api_key, _fastly_service_id, null);
+
+        Future<Response> future = client.softPurgeKeys(keys);
         Response res = future.get();
 
         printResult(res);


### PR DESCRIPTION
Output for the run:

```
Request DefaultHttpRequest(chunked: false)

POST /service/...(redacted)..../purge HTTP/1.1
Fastly-Key: ........... (redacted for security reasons)
Accept: application/json
User-Agent: fastly-api-java-v1.2
Surrogate-Key: a b c d
Connection: keep-alive
Host: api.fastly.com
```

Response:
```
Response DefaultHttpResponse(chunked: false)

HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 138
Fastly-Surrogate-Key-Count: 4
Accept-Ranges: bytes
Date: Fri, 24 Jul 2020 23:54:00 GMT
X-Varnish: 3722527408
Via: 1.1 varnish
X-Served-By: cache-wdc5577-WDC

{ 
    "a": "5577-1591850875-133477325", 
    "b": "5577-1591850875-133477326", 
    "c": "5577-1591850875-133477327", 
    "d": "5577-1591850875-133477328"
 }
```

Reviewer please validate against this doc:

https://developer.fastly.com/reference/api/purging/#bulk-purge-tag

![image](https://user-images.githubusercontent.com/250893/88443875-12780000-cdcf-11ea-845f-d95d6fe83712.png)
