### PR TITLE
NOC-518: [1.2.2] Overload methods to allow custom fastly urls

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,8 @@
 Changelog
 ---------
+1.2.2
+ Added `fastlyUrl` as an optional parameter to all methods, allowing callers to choose specific urls to hit. All methods default to `https://api.fastly.com`
+
 1.2.1
  Added `Fastly-Soft-Purge` header, which was missing in `softPurgeKeys` method
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.split</groupId>
   <artifactId>fastly-api-java</artifactId>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <packaging>jar</packaging>
 
   <name>fastly-api-java</name>

--- a/src/main/java/io/split/fastly/client/FastlyApiClient.java
+++ b/src/main/java/io/split/fastly/client/FastlyApiClient.java
@@ -59,7 +59,11 @@ public class FastlyApiClient {
     }
 
     public Future<Response> vclUpload(int version, String vcl, String id, String name) {
-        String apiUrl = String.format("%s/service/%s/version/%d/vcl", FASTLY_URL, _serviceId, version);
+        return vclUpload(version, vcl, id, name, FASTLY_URL);
+    }
+
+    public Future<Response> vclUpload(int version, String vcl, String id, String name, String fastlyUrl) {
+        String apiUrl = String.format("%s/service/%s/version/%d/vcl", fastlyUrl, _serviceId, version);
         return _asyncHttpExecutor.execute(
                 apiUrl,
                 POST,
@@ -71,8 +75,12 @@ public class FastlyApiClient {
     }
 
     public List<Future<Response>> vclUpdate(int version, Map<String, String> vcl) {
+        return vclUpdate(version, vcl, FASTLY_URL);
+    }
+
+    public List<Future<Response>> vclUpdate(int version, Map<String, String> vcl, String fastlyUrl) {
         return vcl.entrySet().stream().map( e -> {
-            String apiUrl = String.format("%s/service/%s/version/$d/vcl/%s", FASTLY_URL, _serviceId, version, e.getKey());
+            String apiUrl = String.format("%s/service/%s/version/$d/vcl/%s", fastlyUrl, _serviceId, version, e.getKey());
             return _asyncHttpExecutor.execute(
                     apiUrl,
                     PUT,
@@ -118,7 +126,11 @@ public class FastlyApiClient {
     }
 
     public Future<Response> purgeKey(String key, Map<String, String> extraHeaders) {
-        String apiUrl = String.format("%s/service/%s/purge/%s", FASTLY_URL, _serviceId, key);
+        return purgeKey(key, extraHeaders, FASTLY_URL);
+    }
+
+    public Future<Response> purgeKey(String key, Map<String, String> extraHeaders, String fastlyUrl) {
+        String apiUrl = String.format("%s/service/%s/purge/%s", fastlyUrl, _serviceId, key);
         return _asyncHttpExecutor.execute(
                 apiUrl,
                 POST,
@@ -130,18 +142,30 @@ public class FastlyApiClient {
     }
 
     public Future<Response> purgeKeys(List<String> keys) {
-        return purgeKeys(keys, Collections.emptyMap());
+        return purgeKeys(keys, FASTLY_URL);
+    }
+
+    public Future<Response> purgeKeys(List<String> keys, String fastlyUrl) {
+        return purgeKeys(keys, Collections.emptyMap(), fastlyUrl);
     }
 
     public Future<Response> softPurgeKeys(List<String> keys) {
-        return purgeKeys(keys, buildHeaderForSoftPurge(Collections.emptyMap()));
+        return softPurgeKeys(keys, FASTLY_URL);
+    }
+
+    public Future<Response> softPurgeKeys(List<String> keys, String fastlyUrl) {
+        return purgeKeys(keys, buildHeaderForSoftPurge(Collections.emptyMap()), fastlyUrl);
     }
 
     public Future<Response> purgeKeys(List<String> keys, Map<String, String> extraHeaders) {
+        return purgeKeys(keys, extraHeaders, FASTLY_URL);
+    }
+
+    public Future<Response> purgeKeys(List<String> keys, Map<String, String> extraHeaders, String fastlyUrl) {
         Preconditions.checkNotNull(keys, "keys cannot be null!");
         Preconditions.checkArgument(keys.size() <= 256, "Fastly can't purge batches of more than 256 keys");
 
-        String apiUrl = String.format("%s/service/%s/purge", FASTLY_URL, _serviceId);
+        String apiUrl = String.format("%s/service/%s/purge", fastlyUrl, _serviceId);
         return _asyncHttpExecutor.execute(
                 apiUrl,
                 POST,
@@ -154,7 +178,11 @@ public class FastlyApiClient {
     }
 
     public Future<Response>  purgeAll() {
-        String apiUrl = String.format("%s/service/%s/purge_all", FASTLY_URL, _serviceId);
+        return purgeAll(FASTLY_URL);
+    }
+
+    public Future<Response>  purgeAll(String fastlyURL) {
+        String apiUrl = String.format("%s/service/%s/purge_all", fastlyURL, _serviceId);
         return _asyncHttpExecutor.execute(
                 apiUrl,
                 POST,

--- a/src/test/java/io/split/fastly/client/FastlyApiClientTest.java
+++ b/src/test/java/io/split/fastly/client/FastlyApiClientTest.java
@@ -24,6 +24,7 @@ public class FastlyApiClientTest {
     public static final String API_KEY = "someApikey";
     public static final String SERVICE_ID = "someServiceId";
     public static final List<String> SURROGATE_KEYS = Arrays.asList("key1", "key2");
+    public static final String CUSTOM_FASTLY_URL = "http://custom_fastly_url.com";
 
     @Mock
     private FastlyApiClient.AsyncHttpExecutor executor;
@@ -74,6 +75,42 @@ public class FastlyApiClientTest {
                 parametersCaptor.capture());
 
         assertThat(urlCaptor.getValue(), is(String.format("%s/service/%s/purge", FastlyApiClient.FASTLY_URL, SERVICE_ID)));
+        assertThat(methodCaptor.getValue(), is(FastlyApiClient.Method.POST));
+
+        Map<String, String> headers = headersCaptor.getValue();
+        assertThat(headers.get("Fastly-Key"), is(API_KEY));
+        assertThat(headers.get("Accept"), is("application/json"));
+        assertThat(headers.get("User-Agent"), is("fastly-api-java-v" + VersionResolver.instance().getVersion()));
+        assertThat(headers.get("Surrogate-Key"), is(FastlyApiClient.SURROGATE_KEY_JOINER.join(SURROGATE_KEYS)));
+        assertThat(headers.get("Fastly-Soft-Purge"), is("1"));
+    }
+
+    @Test
+    public void testPurgeKeysWithCustomFastlyUrl() {
+        fastlyApiClient.purgeKeys(SURROGATE_KEYS, CUSTOM_FASTLY_URL);
+
+        Mockito.verify(executor).execute(urlCaptor.capture(), methodCaptor.capture(), headersCaptor.capture(),
+                parametersCaptor.capture());
+
+        assertThat(urlCaptor.getValue(), is(String.format("%s/service/%s/purge", CUSTOM_FASTLY_URL, SERVICE_ID)));
+        assertThat(methodCaptor.getValue(), is(FastlyApiClient.Method.POST));
+
+        Map<String, String> headers = headersCaptor.getValue();
+        assertThat(headers.get("Fastly-Key"), is(API_KEY));
+        assertThat(headers.get("Accept"), is("application/json"));
+        assertThat(headers.get("User-Agent"), is("fastly-api-java-v" + VersionResolver.instance().getVersion()));
+        assertThat(headers.get("Surrogate-Key"), is(FastlyApiClient.SURROGATE_KEY_JOINER.join(SURROGATE_KEYS)));
+        assertThat(headers.get("Fastly-Soft-Purge"), is(nullValue()));
+    }
+
+    @Test
+    public void testSoftPurgeKeysWithCustomFastlyUrl() {
+        fastlyApiClient.softPurgeKeys(SURROGATE_KEYS, CUSTOM_FASTLY_URL);
+
+        Mockito.verify(executor).execute(urlCaptor.capture(), methodCaptor.capture(), headersCaptor.capture(),
+                parametersCaptor.capture());
+
+        assertThat(urlCaptor.getValue(), is(String.format("%s/service/%s/purge", CUSTOM_FASTLY_URL, SERVICE_ID)));
         assertThat(methodCaptor.getValue(), is(FastlyApiClient.Method.POST));
 
         Map<String, String> headers = headersCaptor.getValue();


### PR DESCRIPTION
This commit overloads all methods in FastlyApiClient to allow a custom fastly url to be used by the callers. By default, all existing methods that do not have that parameter will use the existing FASTLY_URL constant and have no change in behavior.

This is in order to support split-incident-31 investigations and allow WebAdmin to, on-demand for specific organizations, use the Fastly Proxy service to purge instead of going directly to api.fastly.com

Library version updated to 1.2.2.